### PR TITLE
fix: apply venv dbt resolution to all call sites

### DIFF
--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -6,7 +6,11 @@
  */
 
 import * as vscode from "vscode";
-import { buildDbtCommand, executeInTerminal } from "../core/executor";
+import {
+  buildDbtCommand,
+  executeInTerminal,
+  resolveDbtExecutable,
+} from "../core/executor";
 import { getActiveProject, getDiscovery } from "../extension";
 
 // ---------------------------------------------------------------------------
@@ -15,7 +19,9 @@ import { getActiveProject, getDiscovery } from "../extension";
 
 function getSettings(): { dbtCommand: string; profilesDir: string } {
   const config = vscode.workspace.getConfiguration("dbtCoreTools");
-  const dbtCommand = config.get<string>("dbtCommand", "dbt");
+  const rawDbtCommand = config.get<string>("dbtCommand", "dbt");
+  const wsRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "";
+  const dbtCommand = resolveDbtExecutable(rawDbtCommand, wsRoot);
   const profilesDir = config.get<string>("profilesDir", "");
   return { dbtCommand, profilesDir };
 }

--- a/src/commands/stageExternal.ts
+++ b/src/commands/stageExternal.ts
@@ -7,7 +7,11 @@
  */
 
 import * as vscode from "vscode";
-import { buildDbtCommand, executeInTerminal } from "../core/executor";
+import {
+  buildDbtCommand,
+  executeInTerminal,
+  resolveDbtExecutable,
+} from "../core/executor";
 import { getActiveProject } from "../extension";
 import { extractSourceCalls } from "../utils/patterns";
 
@@ -30,7 +34,9 @@ export async function stageExternalSources(): Promise<void> {
   }
 
   const config = vscode.workspace.getConfiguration("dbtCoreTools");
-  const dbtCommand = config.get<string>("dbtCommand", "dbt");
+  const rawDbtCommand = config.get<string>("dbtCommand", "dbt");
+  const wsRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "";
+  const dbtCommand = resolveDbtExecutable(rawDbtCommand, wsRoot);
   const profilesDir = config.get<string>("profilesDir", "") || undefined;
   const varsConfig = config.get<Record<string, string>>(
     "stageExternalSourcesVars",

--- a/src/features/parseOnSave.ts
+++ b/src/features/parseOnSave.ts
@@ -8,7 +8,11 @@
 
 import * as vscode from "vscode";
 import { spawn, ChildProcess } from "child_process";
-import { buildDbtCommand, splitCommand } from "../core/executor";
+import {
+  buildDbtCommand,
+  splitCommand,
+  resolveDbtExecutable,
+} from "../core/executor";
 import { getDiscovery, getOutputChannel } from "../extension";
 import { resolveWorkspacePath } from "../commands/modelCommands";
 
@@ -99,9 +103,10 @@ async function handleSave(document: vscode.TextDocument): Promise<void> {
   }
 
   // Build the parse command.
-  const dbtCommand = config.get<string>("dbtCommand", "dbt");
+  const rawDbtCommand = config.get<string>("dbtCommand", "dbt");
   const rawProfilesDir = config.get<string>("profilesDir", "");
   const wsRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? "";
+  const dbtCommand = resolveDbtExecutable(rawDbtCommand, wsRoot);
   const profilesDir =
     resolveWorkspacePath(rawProfilesDir || undefined, wsRoot) ?? "";
 


### PR DESCRIPTION
## Summary

- `lifecycle.ts`, `parseOnSave.ts`, and `stageExternal.ts` all read `dbtCommand` from config without calling `resolveDbtExecutable()`, so they used bare `"dbt"` instead of the `.venv/bin/dbt` path
- Clicking the manifest status bar (parse), save-triggered background parse, and stage external sources all failed with `dbt: command not found`

## Test plan

- [ ] Click manifest status bar → `dbt parse` runs using venv path
- [ ] Save a .sql file → background parse uses venv path
- [ ] Run stage external sources → uses venv path

🤖 Generated with [Claude Code](https://claude.com/claude-code)