### PR TITLE
fix: use resetCenter for initial lineage load to bypass default lock

### DIFF
--- a/src/features/lineage/lineagePanel.ts
+++ b/src/features/lineage/lineagePanel.ts
@@ -93,7 +93,8 @@ export class LineageViewProvider implements vscode.WebviewViewProvider {
     });
 
     // Send initial graph data for whatever file is currently open.
-    this.updateCenter();
+    // Use resetCenter (bypasses lock) since lock defaults to on.
+    this._sendResetCenter();
   }
 
   /**


### PR DESCRIPTION
Lock defaults to on, so the initial updateCenter was silently dropped.